### PR TITLE
refactor: name duplication detection types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,15 +25,6 @@ type InferState<Configs> = Configs extends [
     } & InferState<Rest>
   : unknown;
 
-type IsDuplicated<Name, Names extends unknown[]> = Names extends [
-  infer One,
-  ...infer Rest,
-]
-  ? One extends Name
-    ? true
-    : IsDuplicated<Name, Rest>
-  : false;
-
 type HasDuplicatedNames<
   Configs,
   Names extends string[] = [],
@@ -41,11 +32,9 @@ type HasDuplicatedNames<
   SliceConfig<infer Name, infer _Value, infer Actions>,
   ...infer Rest,
 ]
-  ? Name extends Names[number]
-    ? true
-    : IsDuplicated<keyof Actions, Names> extends true
-      ? true
-      : HasDuplicatedNames<Rest, [Name, ...Names]>
+  ? Extract<Name | keyof Actions, Names[number]> extends never
+    ? HasDuplicatedNames<Rest, [Name, ...Names]>
+    : true
   : false;
 
 type HasDuplicatedArgs<Configs, State> = Configs extends [
@@ -78,9 +67,9 @@ export function createSlice<
   return config;
 }
 
-// FIXME no any in a reasonable way?
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function withSlices<Configs extends SliceConfig<string, unknown, any>[]>(
+export function withSlices<
+  Configs extends SliceConfig<string, unknown, NonNullable<unknown>>[],
+>(
   ...configs: Configs
 ): IsValidConfigs<Configs> extends true
   ? (

--- a/tests/02_type.spec.tsx
+++ b/tests/02_type.spec.tsx
@@ -26,6 +26,44 @@ test('slice type: single slice', () => {
   >(true);
 });
 
+test('slice type: withSlices', () => {
+  const countSlice = createSlice({
+    name: 'count',
+    value: 0,
+    actions: {
+      inc: () => (prev) => prev + 1,
+      reset: () => () => 0,
+    },
+  });
+
+  const textSlice = createSlice({
+    name: 'text',
+    value: 'Hello',
+    actions: {
+      updateText: (newText: string) => () => newText,
+      reset: () => () => 'Hello',
+    },
+  });
+
+  type CountTextState = {
+    count: number;
+    inc: () => void;
+    text: string;
+    updateText: (newText: string) => void;
+    reset: () => void;
+  };
+
+  const slices = withSlices(countSlice, textSlice);
+
+  expectType<
+    (
+      set: (fn: (prevState: CountTextState) => Partial<CountTextState>) => void,
+    ) => CountTextState
+  >(slices);
+
+  expectType<TypeEqual<typeof slices, never>>(false);
+});
+
 test('name collisions: same slice names', () => {
   const countSlice = createSlice({
     name: 'count',


### PR DESCRIPTION
Additional thoughts: from the TS perspective, working with an array of configs is difficult because of generics around Value type. An easier approach in terms of TS would be API like this:

```js
withSlices(countSlice).and(textSlice);
```

Which also means that you can get rid of "createSlice"

```js
  withSlices({
    name: 'count',
    value: 0,
    actions: {
      inc: () => (prev) => prev + 1,
      reset: () => () => 0,
    },
  }).and({
    name: 'text',
    value: 'Hello',
    actions: {
      updateText: (newText: string) => () => newText,
      reset: () => () => 'Hello',
    },
  });
```

Any pipe-type API like this would be way more robust and easy to write in TS.

But as always, the question is do I want to think typescript-first, or api-first? Or is it possible to prioritize both at the same time?