### PR TITLE
Add basic tests for component that utilizes new `withActions` 

### DIFF
--- a/tests/03_component.spec.tsx
+++ b/tests/03_component.spec.tsx
@@ -1,46 +1,10 @@
 import { afterEach, expect, test } from 'vitest';
-import { createContext, useContext, useRef } from 'react';
 import type { ReactNode } from 'react';
-import { create, useStore } from 'zustand';
-import type { StoreApi } from 'zustand';
+import { create } from 'zustand';
 import { cleanup, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { createSlice, withSlices } from 'zustand-slices';
-
-type ExtractState<S> = S extends {
-  getState: () => infer State;
-}
-  ? State
-  : never;
-
-function createZustandContext<Store extends StoreApi<unknown>>(
-  initializeStore: () => Store,
-) {
-  const Context = createContext<Store | undefined>(undefined);
-  const StoreProvider = ({ children }: { children: ReactNode }) => {
-    const storeRef = useRef<Store>();
-    if (!storeRef.current) {
-      storeRef.current = initializeStore();
-    }
-    return (
-      <Context.Provider value={storeRef.current}>{children}</Context.Provider>
-    );
-  };
-  function useStoreApi() {
-    const store = useContext(Context);
-    if (!store) {
-      throw new Error('useStoreApi must be used within a StoreProvider');
-    }
-    return store;
-  }
-  function useSelector<Selected>(
-    selector: (state: ExtractState<Store>) => Selected,
-  ) {
-    const store = useStoreApi();
-    return useStore(store, selector);
-  }
-  return { StoreProvider, useStoreApi, useSelector };
-}
+import createZustandContext from './utils/createZustandContext.js';
 
 const countSlice = createSlice({
   name: 'count',

--- a/tests/04_componentWithActions.spec.tsx
+++ b/tests/04_componentWithActions.spec.tsx
@@ -1,0 +1,103 @@
+import { afterEach, expect, test } from 'vitest';
+import type { ReactNode } from 'react';
+import { create } from 'zustand';
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { createSlice, withSlices, withActions } from 'zustand-slices';
+import createZustandContext from './utils/createZustandContext.js';
+
+const countSlice = createSlice({
+  name: 'count',
+  value: 0,
+  actions: {
+    inc: () => (state) => state + 1,
+    set: (newCount: number) => () => newCount,
+  },
+});
+
+const textSlice = createSlice({
+  name: 'text',
+  value: 'Hello',
+  actions: {
+    updateText: (text: string) => () => text,
+  },
+});
+
+const { StoreProvider, useStoreApi, useSelector } = createZustandContext(() =>
+  create(
+    withActions(withSlices(countSlice, textSlice), {
+      setCountWithTextLength: () => (state) => {
+        state.set(state.text.length);
+      },
+    }),
+  ),
+);
+
+const renderWithStoreProvider = (app: ReactNode) =>
+  render(app, { wrapper: StoreProvider });
+
+const Counter = () => {
+  const count = useSelector((state) => state.count);
+  const { inc } = useStoreApi().getState();
+  return (
+    <div>
+      <p data-testid="count">{count}</p>
+      <button type="button" onClick={inc}>
+        Increment
+      </button>
+    </div>
+  );
+};
+
+const Text = () => {
+  const text = useSelector((state) => state.text);
+  const { updateText } = useStoreApi().getState();
+  return (
+    <div>
+      <input value={text} onChange={(e) => updateText(e.target.value)} />
+    </div>
+  );
+};
+
+const App = () => {
+  const { setCountWithTextLength } = useStoreApi().getState();
+  return (
+    <div>
+      <Counter />
+      <Text />
+      <p data-testid="set-text-length-to-count">
+        <button type="button" onClick={setCountWithTextLength}>
+          Set Text Length to Count
+        </button>
+      </p>
+    </div>
+  );
+};
+
+afterEach(cleanup);
+
+test('should render the app', () => {
+  renderWithStoreProvider(<App />);
+  expect(screen.getByTestId('count')).toHaveTextContent('0');
+  expect(screen.getByRole('textbox')).toBeInTheDocument();
+  expect(screen.getByTestId('set-text-length-to-count')).toBeInTheDocument();
+});
+
+test('should set text length to count', async () => {
+  const user = userEvent.setup();
+  renderWithStoreProvider(<App />);
+
+  // Increment count
+  await user.click(screen.getByRole('button', { name: 'Increment' }));
+  expect(screen.getByTestId('count')).toHaveTextContent('1');
+
+  // Change text
+  await user.type(screen.getByRole('textbox'), ' World');
+  expect(screen.getByRole('textbox')).toHaveValue('Hello World');
+
+  // Set text length to count
+  await user.click(
+    screen.getByRole('button', { name: 'Set Text Length to Count' }),
+  );
+  expect(screen.getByTestId('count')).toHaveTextContent('11');
+});

--- a/tests/utils/createZustandContext.tsx
+++ b/tests/utils/createZustandContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { useStore } from 'zustand';
+import type { StoreApi } from 'zustand';
+
+type ExtractState<S> = S extends {
+  getState: () => infer State;
+}
+  ? State
+  : never;
+
+function createZustandContext<Store extends StoreApi<unknown>>(
+  initializeStore: () => Store,
+) {
+  const Context = createContext<Store | undefined>(undefined);
+  const StoreProvider = ({ children }: { children: ReactNode }) => {
+    const storeRef = useRef<Store>();
+    if (!storeRef.current) {
+      storeRef.current = initializeStore();
+    }
+    return (
+      <Context.Provider value={storeRef.current}>{children}</Context.Provider>
+    );
+  };
+  function useStoreApi() {
+    const store = useContext(Context);
+    if (!store) {
+      throw new Error('useStoreApi must be used within a StoreProvider');
+    }
+    return store;
+  }
+  function useSelector<Selected>(
+    selector: (state: ExtractState<Store>) => Selected,
+  ) {
+    const store = useStoreApi();
+    return useStore(store, selector);
+  }
+  return { StoreProvider, useStoreApi, useSelector };
+}
+
+export default createZustandContext;


### PR DESCRIPTION
Added some basic tests for new `withActions`, similarly to existing component ones. Moreover, I moved the `createZustandContext` function to a reusable test util. Maybe we could also make the test components `Counter`, `Text`,  etc. reusable too.  