### PR TITLE
Set `withActions` return type to `never` in case of invalid actions

### DIFF
--- a/src/with-actions.ts
+++ b/src/with-actions.ts
@@ -19,15 +19,15 @@ export function withActions<
 >(
   config: (set: (fn: (prevState: State) => Partial<State>) => void) => State,
   actions: Actions,
-): (
-  set: (
-    fn: (
-      prevState: State & InferStateActions<Actions>,
-    ) => Partial<State & InferStateActions<Actions>>,
-  ) => void,
-  get: () => State & InferStateActions<Actions>,
-) => IsValidActions<State, Actions> extends true
-  ? State & InferStateActions<Actions>
+): IsValidActions<State, Actions> extends true
+  ? (
+      set: (
+        fn: (
+          prevState: State & InferStateActions<Actions>,
+        ) => Partial<State & InferStateActions<Actions>>,
+      ) => void,
+      get: () => State & InferStateActions<Actions>,
+    ) => State & InferStateActions<Actions>
   : never {
   return ((
     set: (


### PR DESCRIPTION
If you agree, I think it would be better to keep a consistent return type for `withActions` in case of invalid actions, similar to `withSlices`. So I made a small change in order to return `never` in case `IsValidActions` equals `false`. 

Please feel free to close this PR if you find this change unnecessary.