### PR TITLE
Implement `IsValidActions` type

### DIFF
--- a/src/with-actions.ts
+++ b/src/with-actions.ts
@@ -8,8 +8,8 @@ type InferStateActions<Actions> = Actions extends {
     }
   : unknown;
 
-// FIXME we should check name collisions between state and actions (help wanted)
-type IsValidActions<_State, _Actions> = true;
+type IsValidActions<State, Actions> =
+  Extract<keyof State, keyof Actions> extends never ? true : false;
 
 export function withActions<
   State,

--- a/tests/02_type.spec.tsx
+++ b/tests/02_type.spec.tsx
@@ -1,181 +1,187 @@
-import { test } from 'vitest';
+import { test, describe } from 'vitest';
 import { expectType } from 'ts-expect';
 import type { TypeEqual } from 'ts-expect';
 
 import { createSlice, withSlices } from 'zustand-slices';
 
-test('slice type: single slice', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  expectType<
-    TypeEqual<
-      {
-        name: 'count';
-        value: number;
-        actions: {
-          inc: () => (prev: number) => number;
-        };
+describe('createSlice', () => {
+  test('slice type: single slice', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
       },
-      typeof countSlice
-    >
-  >(true);
+    });
+    expectType<
+      TypeEqual<
+        {
+          name: 'count';
+          value: number;
+          actions: {
+            inc: () => (prev: number) => number;
+          };
+        },
+        typeof countSlice
+      >
+    >(true);
+  });
 });
 
-test('slice type: withSlices', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-      reset: () => () => 0,
-    },
+describe('withSlices', () => {
+  test('slice type, no collisions', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+        reset: () => () => 0,
+      },
+    });
+
+    const textSlice = createSlice({
+      name: 'text',
+      value: 'Hello',
+      actions: {
+        updateText: (newText: string) => () => newText,
+        reset: () => () => 'Hello',
+      },
+    });
+
+    type CountTextState = {
+      count: number;
+      inc: () => void;
+      text: string;
+      updateText: (newText: string) => void;
+      reset: () => void;
+    };
+
+    const slices = withSlices(countSlice, textSlice);
+
+    expectType<
+      (
+        set: (
+          fn: (prevState: CountTextState) => Partial<CountTextState>,
+        ) => void,
+      ) => CountTextState
+    >(slices);
+
+    expectType<TypeEqual<typeof slices, never>>(false);
   });
 
-  const textSlice = createSlice({
-    name: 'text',
-    value: 'Hello',
-    actions: {
-      updateText: (newText: string) => () => newText,
-      reset: () => () => 'Hello',
-    },
+  test('name collisions: same slice names', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    expectType<never>(withSlices(countSlice, anotherCountSlice));
   });
 
-  type CountTextState = {
-    count: number;
-    inc: () => void;
-    text: string;
-    updateText: (newText: string) => void;
-    reset: () => void;
-  };
+  test('name collisions: slice name and action name', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'anotherCount',
+      value: 0,
+      actions: {
+        count: () => (prev) => prev + 1,
+      },
+    });
+    expectType<never>(withSlices(countSlice, anotherCountSlice));
+  });
 
-  const slices = withSlices(countSlice, textSlice);
+  test('name collisions: slice name and action name (overlapping case)', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'anotherCount',
+      value: 0,
+      actions: {
+        count: () => (prev) => prev + 1,
+        dec: () => (prev) => prev - 1,
+      },
+    });
+    expectType<never>(withSlices(countSlice, anotherCountSlice));
+  });
 
-  expectType<
-    (
-      set: (fn: (prevState: CountTextState) => Partial<CountTextState>) => void,
-    ) => CountTextState
-  >(slices);
+  test('args collisions: different args', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: (s: string) => (prev) => prev + (s ? 2 : 1),
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'anotherCount',
+      value: 0,
+      actions: {
+        inc: (n: number) => (prev) => prev + n,
+      },
+    });
+    expectType<never>(withSlices(countSlice, anotherCountSlice));
+    expectType<never>(withSlices(anotherCountSlice, countSlice));
+  });
 
-  expectType<TypeEqual<typeof slices, never>>(false);
-});
+  test('args collisions: same args', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'anotherCount',
+      value: 0,
+      actions: {
+        anotherInc: (n: number) => (prev) => prev + n,
+      },
+    });
+    expectType<(...args: never[]) => unknown>(
+      withSlices(countSlice, anotherCountSlice),
+    );
+    expectType<(...args: never[]) => unknown>(
+      withSlices(anotherCountSlice, countSlice),
+    );
+  });
 
-test('name collisions: same slice names', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
+  test('args collisions: overload case', () => {
+    const countSlice = createSlice({
+      name: 'count',
+      value: 0,
+      actions: {
+        inc: () => (prev) => prev + 1,
+      },
+    });
+    const anotherCountSlice = createSlice({
+      name: 'anotherCount',
+      value: 0,
+      actions: {
+        inc: (n: number) => (prev) => prev + n,
+      },
+    });
+    expectType<never>(withSlices(countSlice, anotherCountSlice));
+    expectType<never>(withSlices(anotherCountSlice, countSlice));
   });
-  const anotherCountSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  expectType<never>(withSlices(countSlice, anotherCountSlice));
-});
-
-test('name collisions: slice name and action name', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  const anotherCountSlice = createSlice({
-    name: 'anotherCount',
-    value: 0,
-    actions: {
-      count: () => (prev) => prev + 1,
-    },
-  });
-  expectType<never>(withSlices(countSlice, anotherCountSlice));
-});
-
-test('name collisions: slice name and action name (overlapping case)', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  const anotherCountSlice = createSlice({
-    name: 'anotherCount',
-    value: 0,
-    actions: {
-      count: () => (prev) => prev + 1,
-      dec: () => (prev) => prev - 1,
-    },
-  });
-  expectType<never>(withSlices(countSlice, anotherCountSlice));
-});
-
-test('args collisions: different args', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: (s: string) => (prev) => prev + (s ? 2 : 1),
-    },
-  });
-  const anotherCountSlice = createSlice({
-    name: 'anotherCount',
-    value: 0,
-    actions: {
-      inc: (n: number) => (prev) => prev + n,
-    },
-  });
-  expectType<never>(withSlices(countSlice, anotherCountSlice));
-  expectType<never>(withSlices(anotherCountSlice, countSlice));
-});
-
-test('args collisions: same args', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  const anotherCountSlice = createSlice({
-    name: 'anotherCount',
-    value: 0,
-    actions: {
-      anotherInc: (n: number) => (prev) => prev + n,
-    },
-  });
-  expectType<(...args: never[]) => unknown>(
-    withSlices(countSlice, anotherCountSlice),
-  );
-  expectType<(...args: never[]) => unknown>(
-    withSlices(anotherCountSlice, countSlice),
-  );
-});
-
-test('args collisions: overload case', () => {
-  const countSlice = createSlice({
-    name: 'count',
-    value: 0,
-    actions: {
-      inc: () => (prev) => prev + 1,
-    },
-  });
-  const anotherCountSlice = createSlice({
-    name: 'anotherCount',
-    value: 0,
-    actions: {
-      inc: (n: number) => (prev) => prev + n,
-    },
-  });
-  expectType<never>(withSlices(countSlice, anotherCountSlice));
-  expectType<never>(withSlices(anotherCountSlice, countSlice));
 });


### PR DESCRIPTION
This is an implementation of `IsValidActions` type, aiming to detect name collisions between state and actions. I also introduced the usage of `describe` in type tests in order to group them and then added test cases for validating `withActions` types.

Please let me know if any additional changes are required or if there are potential cases where this approach might not work. 