### PR TITLE
Detect invalid actions in `withActions`

### DIFF
--- a/src/with-actions.ts
+++ b/src/with-actions.ts
@@ -9,7 +9,7 @@ type InferStateActions<Actions> = Actions extends {
   : unknown;
 
 type IsValidActions<State, Actions> =
-  Extract<keyof State, keyof Actions> extends never ? true : false;
+  Extract<keyof Actions, keyof State> extends never ? Actions : never;
 
 export function withActions<
   State,
@@ -18,17 +18,15 @@ export function withActions<
   },
 >(
   config: (set: (fn: (prevState: State) => Partial<State>) => void) => State,
-  actions: Actions,
-): IsValidActions<State, Actions> extends true
-  ? (
-      set: (
-        fn: (
-          prevState: State & InferStateActions<Actions>,
-        ) => Partial<State & InferStateActions<Actions>>,
-      ) => void,
-      get: () => State & InferStateActions<Actions>,
-    ) => State & InferStateActions<Actions>
-  : never {
+  actions: IsValidActions<State, Actions>,
+): (
+  set: (
+    fn: (
+      prevState: State & InferStateActions<Actions>,
+    ) => Partial<State & InferStateActions<Actions>>,
+  ) => void,
+  get: () => State & InferStateActions<Actions>,
+) => State & InferStateActions<Actions> {
   return ((
     set: (
       fn: (

--- a/tests/02_type.spec.tsx
+++ b/tests/02_type.spec.tsx
@@ -256,24 +256,22 @@ describe('withActions', () => {
       },
     });
 
-    expectType<never>(
-      withActions(withSlices(countSlice, textSlice), {
-        count: () => (state) => {
-          state.set(state.text.length);
-        },
-      }),
-    );
+    // @ts-expect-error invalid actions
+    withActions(withSlices(countSlice, textSlice), {
+      count: () => (state) => {
+        state.set(state.text.length);
+      },
+    });
 
-    expectType<never>(
-      withActions(withSlices(countSlice, textSlice), {
-        count: () => (state) => {
-          state.set(state.text.length);
-        },
-        text: () => (state) => {
-          state.updateText('Hello world');
-        },
-      }),
-    );
+    // @ts-expect-error invalid actions
+    withActions(withSlices(countSlice, textSlice), {
+      count: () => (state) => {
+        state.set(state.text.length);
+      },
+      text: () => (state) => {
+        state.updateText('Hello world');
+      },
+    });
   });
 
   test('name collisions: action names', () => {
@@ -294,24 +292,22 @@ describe('withActions', () => {
       },
     });
 
-    expectType<never>(
-      withActions(withSlices(countSlice, textSlice), {
-        inc: () => (state) => {
-          state.set(state.count + 1);
-        },
-      }),
-    );
+    // @ts-expect-error invalid actions
+    withActions(withSlices(countSlice, textSlice), {
+      inc: () => (state) => {
+        state.set(state.count + 1);
+      },
+    });
 
-    expectType<never>(
-      withActions(withSlices(countSlice, textSlice), {
-        inc: () => (state) => {
-          state.set(state.count + 1);
-        },
-        updateText: () => (state) => {
-          state.updateText('Hello World');
-        },
-      }),
-    );
+    // @ts-expect-error invalid actions
+    withActions(withSlices(countSlice, textSlice), {
+      inc: () => (state) => {
+        state.set(state.count + 1);
+      },
+      updateText: () => (state) => {
+        state.updateText('Hello World');
+      },
+    });
   });
 
   test('name collisions: action and slice names', () => {
@@ -332,22 +328,21 @@ describe('withActions', () => {
       },
     });
 
-    expectType<never>(
-      withActions(withSlices(countSlice, textSlice), {
-        inc: () => (state) => {
-          state.set(state.count + 1);
-        },
-        updateText: () => (state) => {
-          state.updateText('Hello World');
-        },
-        count: () => (state) => {
-          state.set(state.text.length);
-        },
-        text: () => (state) => {
-          state.updateText('Hello world');
-        },
-      }),
-    );
+    // @ts-expect-error invalid actions
+    withActions(withSlices(countSlice, textSlice), {
+      inc: () => (state) => {
+        state.set(state.count + 1);
+      },
+      updateText: () => (state) => {
+        state.updateText('Hello World');
+      },
+      count: () => (state) => {
+        state.set(state.text.length);
+      },
+      text: () => (state) => {
+        state.updateText('Hello world');
+      },
+    });
   });
 });
 
@@ -365,5 +360,23 @@ describe('create', () => {
     });
     // @ts-expect-error invalid configs
     create(withSlices(countSlice, anotherCountSlice));
+
+    create(
+      // @ts-expect-error invalid configs
+      withActions(withSlices(countSlice, anotherCountSlice), {
+        anotherCount: () => () => {},
+      }),
+    );
+
+    create(
+      withActions(
+        // @ts-expect-error invalid configs
+        withSlices(countSlice, anotherCountSlice),
+        // @ts-expect-error invalid actions
+        {
+          count: () => (state) => state.count,
+        },
+      ),
+    );
   });
 });


### PR DESCRIPTION
@dai-shi I refactored the `withActions` util to issue a TypeScript warning on invalid parameters, following our discussion in #16. 

If you approve of these modifications, I can create a separate PR to update the `docs` section regarding collision handling and integrate our recent changes.