### PR TITLE
immer example for createSliceWithImmer

### DIFF
--- a/examples/04_immer/index.html
+++ b/examples/04_immer/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/04_immer/package.json
+++ b/examples/04_immer/package.json
@@ -7,7 +7,8 @@
     "react": "latest",
     "react-dom": "latest",
     "zustand": "latest",
-    "zustand-slices": "latest"
+    "zustand-slices": "latest",
+    "immer": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/examples/04_immer/package.json
+++ b/examples/04_immer/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "immer": "latest",
     "react": "latest",
     "react-dom": "latest",
     "zustand": "latest",
-    "zustand-slices": "latest",
-    "immer": "latest"
+    "zustand-slices": "latest"
   },
   "devDependencies": {
     "@types/react": "latest",

--- a/examples/04_immer/package.json
+++ b/examples/04_immer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "react": "latest",
+    "react-dom": "latest",
+    "zustand": "latest",
+    "zustand-slices": "latest"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "typescript": "latest",
+    "vite": "latest"
+  },
+  "scripts": {
+    "dev": "vite"
+  }
+}

--- a/examples/04_immer/src/app.tsx
+++ b/examples/04_immer/src/app.tsx
@@ -5,14 +5,14 @@ import { createSliceWithImmer } from 'zustand-slices/immer';
 const countSlice = createSliceWithImmer({
   name: 'count',
   value: {
-    count: 0
+    count: 0,
   },
   actions: {
     inc: () => (state) => {
       state.count += 1;
     },
     reset: () => () => ({ count: 0 }),
-    },
+  },
 });
 
 const textSlice = createSliceWithImmer({

--- a/examples/04_immer/src/app.tsx
+++ b/examples/04_immer/src/app.tsx
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { withSlices } from 'zustand-slices';
+import { createSliceWithImmer } from 'zustand-slices/immer';
+
+const countSlice = createSliceWithImmer({
+  name: 'count',
+  value: {
+    count: 0
+  },
+  actions: {
+    inc: () => (state) => {
+      state.count += 1;
+    },
+    reset: () => () => ({ count: 0 }),
+    },
+});
+
+const textSlice = createSliceWithImmer({
+  name: 'text',
+  value: 'Hello',
+  actions: {
+    updateText: (newText: string) => () => newText,
+    reset: () => () => 'Hello',
+  },
+});
+
+const useCountStore = create(withSlices(countSlice, textSlice));
+
+const Counter = () => {
+  const { count } = useCountStore((state) => state.count);
+  const text = useCountStore((state) => state.text);
+  const { inc, updateText, reset } = useCountStore.getState();
+  return (
+    <>
+      <p>
+        Count: {count}
+        <button type="button" onClick={inc}>
+          +1
+        </button>
+      </p>
+      <p>
+        <input value={text} onChange={(e) => updateText(e.target.value)} />
+      </p>
+      <p>
+        <button type="button" onClick={reset}>
+          Reset
+        </button>
+      </p>
+    </>
+  );
+};
+
+const App = () => (
+  <div>
+    <Counter />
+  </div>
+);
+
+export default App;

--- a/examples/04_immer/src/main.tsx
+++ b/examples/04_immer/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import App from './app';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/04_immer/tsconfig.json
+++ b/examples/04_immer/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "es2018",
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "jsx": "react-jsx"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "examples:01_counter": "DIR=01_counter vite",
     "examples:02_async": "DIR=02_async vite",
     "examples:03_actions": "DIR=03_actions vite",
-    "examples:04_immer": "DIR=04_immer vite" 
+    "examples:04_immer": "DIR=04_immer vite"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "test:spec": "vitest run",
     "examples:01_counter": "DIR=01_counter vite",
     "examples:02_async": "DIR=02_async vite",
-    "examples:03_actions": "DIR=03_actions vite"
+    "examples:03_actions": "DIR=03_actions vite",
+    "examples:04_immer": "DIR=04_immer vite"
   },
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "examples:01_counter": "DIR=01_counter vite",
     "examples:02_async": "DIR=02_async vite",
     "examples:03_actions": "DIR=03_actions vite",
-    "examples:04_immer": "DIR=04_immer vite"
+    "examples:04_immer": "DIR=04_immer vite" 
   },
   "keywords": [
     "react",


### PR DESCRIPTION
Example case for `createSlicesWithImmer`

Also primitives values for slices can be used with explicit returns that do not modify the draft state as shown in `textSlice` so that's nice