### PR TITLE
Docs: update example to prevent action name collision

### DIFF
--- a/docs/getting-started/01_introduction.md
+++ b/docs/getting-started/01_introduction.md
@@ -37,7 +37,7 @@ const countSlice = createSlice({
   value: 0,
   actions: {
     inc: () => (prev) => prev + 1,
-    reset: () => () => 0,
+    resetCount: () => () => 0,
   },
 });
 
@@ -46,7 +46,7 @@ const textSlice = createSlice({
   value: 'Hello',
   actions: {
     updateText: (newText: string) => () => newText,
-    reset: () => () => 'Hello',
+    resetText: () => () => 'Hello',
   },
 });
 ```


### PR DESCRIPTION
In the getting started section example, two actions have the same name, which will result in text action not working. This PR renames them to prevent collision and probable confusion.