### PR TITLE
Docs: clarify action merging behavior when combining slices

### DIFF
--- a/docs/getting-started/01_introduction.md
+++ b/docs/getting-started/01_introduction.md
@@ -59,6 +59,8 @@ By utilizing `create` from Zustand, you can combine these slices into a single s
 const useCountStore = create(withSlices(countSlice, textSlice));
 ```
 
+> 💡 **Note:** Actions with the same name across slices are merged into a single action in the combined store. Calling such an action executes the corresponding actions from each slice. For example, since both slices have a `reset` action, calling `reset` will reset both `count` and `text` to their initial values.
+
 ### Easily utilize it in your components
 
 Finally, you can seamlessly integrate and access your store directly into your component logic utilizing the `useCountStore` hook.


### PR DESCRIPTION
When I tried the code myself, I wasn't expecting the actions to be merged and thought it was a mistake. It was concluded, [in another discussion](https://github.com/zustandjs/zustand-slices/pull/29#issuecomment-2378917007), similar confusion might arise when others try it too, and that 'this "action merging" behavior is one of features of this fairly opinionated lib, so it should be clearly stated somewhere'. I thought it would be best not to let it be forgotten and "combining slices" part in the getting started section, right after the relevant example, is a good place for a clarification. Feel free to edit the change or altogether reject it if it is not the proper place.